### PR TITLE
Implement reusable JWT auth workflow

### DIFF
--- a/src/main/kotlin/cr/una/pai/dto/AuthDto.kt
+++ b/src/main/kotlin/cr/una/pai/dto/AuthDto.kt
@@ -18,5 +18,7 @@ data class RefreshTokenRequest(
 
 data class AuthTokensResponse(
     val accessToken: String,
-    val refreshToken: String
+    val refreshToken: String,
+    val accessTokenExpiresIn: Long,
+    val refreshTokenExpiresIn: Long
 )

--- a/src/main/kotlin/cr/una/pai/security/JwtProperties.kt
+++ b/src/main/kotlin/cr/una/pai/security/JwtProperties.kt
@@ -4,7 +4,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 import java.time.Duration
 
-@ConfigurationProperties(prefix = "security.jwt")
+@ConfigurationProperties(prefix = "app.jwt")
 data class JwtProperties(
     val secret: String,
     val issuer: String,

--- a/src/main/kotlin/cr/una/pai/security/JwtService.kt
+++ b/src/main/kotlin/cr/una/pai/security/JwtService.kt
@@ -27,10 +27,20 @@ class JwtService(
     }
 
     fun generateAccessToken(user: User, primaryRole: String?): String =
-        generateToken(user = user, role = primaryRole, tokenType = properties.accessTokenType, ttlSeconds = properties.accessTokenTtl.seconds)
+        generateToken(
+            user = user,
+            role = primaryRole,
+            tokenType = properties.accessTokenType,
+            ttlSeconds = properties.accessTokenTtl.toSeconds()
+        )
 
     fun generateRefreshToken(user: User): String =
-        generateToken(user = user, role = null, tokenType = properties.refreshTokenType, ttlSeconds = properties.refreshTokenTtl.seconds)
+        generateToken(
+            user = user,
+            role = null,
+            tokenType = properties.refreshTokenType,
+            ttlSeconds = properties.refreshTokenTtl.toSeconds()
+        )
 
     private fun generateToken(user: User, role: String?, tokenType: String, ttlSeconds: Long): String {
         val userId = requireNotNull(user.id) { "User must have an id to issue tokens" }
@@ -63,5 +73,7 @@ class JwtService(
 
     fun refreshTokenType(): String = properties.refreshTokenType
 
-    fun refreshTokenTtl(): Long = properties.refreshTokenTtl.seconds
+    fun refreshTokenTtl(): Long = properties.refreshTokenTtl.toSeconds()
+
+    fun accessTokenTtl(): Long = properties.accessTokenTtl.toSeconds()
 }

--- a/src/main/kotlin/cr/una/pai/service/AuthService.kt
+++ b/src/main/kotlin/cr/una/pai/service/AuthService.kt
@@ -44,7 +44,12 @@ class AuthService(
         val refreshToken = jwtService.generateRefreshToken(user)
         persistRefreshToken(user.id!!, refreshToken)
 
-        return AuthTokensResponse(accessToken = accessToken, refreshToken = refreshToken)
+        return AuthTokensResponse(
+            accessToken = accessToken,
+            refreshToken = refreshToken,
+            accessTokenExpiresIn = jwtService.accessTokenTtl(),
+            refreshTokenExpiresIn = jwtService.refreshTokenTtl()
+        )
     }
 
     @Transactional
@@ -81,7 +86,12 @@ class AuthService(
         val newRefreshToken = jwtService.generateRefreshToken(user)
         persistRefreshToken(userId, newRefreshToken)
 
-        return AuthTokensResponse(accessToken = accessToken, refreshToken = newRefreshToken)
+        return AuthTokensResponse(
+            accessToken = accessToken,
+            refreshToken = newRefreshToken,
+            accessTokenExpiresIn = jwtService.accessTokenTtl(),
+            refreshTokenExpiresIn = jwtService.refreshTokenTtl()
+        )
     }
 
     @Transactional

--- a/src/main/kotlin/cr/una/pai/web/AuthController.kt
+++ b/src/main/kotlin/cr/una/pai/web/AuthController.kt
@@ -25,12 +25,20 @@ class AuthController(
 ) {
 
     @PostMapping("/login")
-    fun login(@Valid @RequestBody request: LoginRequest): ResponseEntity<AuthTokensResponse> =
-        ResponseEntity.ok(authService.login(request))
+    fun login(@Valid @RequestBody request: LoginRequest): ResponseEntity<AuthTokensResponse> {
+        val tokens = authService.login(request)
+        return ResponseEntity.ok()
+            .header(REFRESH_TOKEN_HEADER, tokens.refreshToken)
+            .body(tokens)
+    }
 
     @PostMapping("/refresh")
-    fun refresh(@Valid @RequestBody request: RefreshTokenRequest): ResponseEntity<AuthTokensResponse> =
-        ResponseEntity.ok(authService.refresh(request))
+    fun refresh(@Valid @RequestBody request: RefreshTokenRequest): ResponseEntity<AuthTokensResponse> {
+        val tokens = authService.refresh(request)
+        return ResponseEntity.ok()
+            .header(REFRESH_TOKEN_HEADER, tokens.refreshToken)
+            .body(tokens)
+    }
 
     @PostMapping("/logout")
     fun logout(@Valid @RequestBody request: RefreshTokenRequest): ResponseEntity<Void> {
@@ -46,3 +54,5 @@ class AuthController(
     fun handleInvalidRefresh(ex: InvalidRefreshTokenException): ResponseEntity<Map<String, String?>> =
         ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(mapOf("error" to ex.message))
 }
+
+private const val REFRESH_TOKEN_HEADER = "X-Refresh-Token"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -53,7 +53,7 @@ api.endpoints.calendar=${API_ENDPOINTS_CALENDAR:${api.base-path}/calendar}
 api.endpoints.auth=${API_ENDPOINTS_AUTH:${api.base-path}/auth}
 
 # Configuración JWT
-security.jwt.secret=${SECURITY_JWT_SECRET:VGVzdFNlY3JldEtleUZvclBBSS0xMjM0NTY3ODkwMTIzNDU2Nzg5MDE=}
-security.jwt.issuer=${SECURITY_JWT_ISSUER:PAI Backend}
-security.jwt.access-token-ttl=${SECURITY_JWT_ACCESS_TTL:PT15M}
-security.jwt.refresh-token-ttl=${SECURITY_JWT_REFRESH_TTL:P7D}
+app.jwt.secret=${APP_JWT_SECRET:VGVzdFNlY3JldEtleUZvclBBSS0xMjM0NTY3ODkwMTIzNDU2Nzg5MDE=}
+app.jwt.issuer=${APP_JWT_ISSUER:PAI Backend}
+app.jwt.access-token-ttl=${APP_JWT_ACCESS_TTL:PT15M}
+app.jwt.refresh-token-ttl=${APP_JWT_REFRESH_TTL:P7D}


### PR DESCRIPTION
## Summary
- move JWT configuration to the reusable `app.jwt` namespace and expose TTL helpers
- enrich the authentication response with expiry metadata and emit the refresh token via header
- adjust token persistence to continue rotating refresh tokens with the new helpers

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68fa431c1420832e89c54e5566a51ea4