### PR TITLE
Configure Kotlin source set for kapt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,12 @@ repositories {
 	mavenCentral()
 }
 
+sourceSets {
+        main {
+                java.srcDirs("src/main/kotlin")
+        }
+}
+
 dependencies {
 	// MapStruct core
 	implementation("org.mapstruct:mapstruct:1.6.0")


### PR DESCRIPTION
## Summary
- configure the main source set to point Kapt at the Kotlin sources

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69012f195ba0832e9b03fc4b60a51e9e