### PR TITLE
Allow role assignment endpoint without authentication

### DIFF
--- a/src/main/kotlin/cr/una/pai/domain/Configuration.kt
+++ b/src/main/kotlin/cr/una/pai/domain/Configuration.kt
@@ -155,6 +155,7 @@ class JwtSecurityConfiguration(
                         "${authBasePath.ensureLeadingSlash()}/refresh",
                         "${authBasePath.ensureLeadingSlash()}/logout"
                     ).permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/roles/user/**/role/**").permitAll()
                     .requestMatchers("/api/v1/unsecure/**").permitAll()
                     .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/webjars/**").permitAll()
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()


### PR DESCRIPTION
## Summary
- permit unauthenticated POST requests to the role assignment endpoint so it no longer requires a JWT token

## Testing
- ./gradlew test *(fails: missing Java 17 toolchain in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690a4aba3ba4832e9f849d18eec87c05