### PR TITLE
access to roles endpoint

### DIFF
--- a/src/main/kotlin/cr/una/pai/domain/Configuration.kt
+++ b/src/main/kotlin/cr/una/pai/domain/Configuration.kt
@@ -159,6 +159,7 @@ class JwtSecurityConfiguration(
                         "${authBasePath.ensureLeadingSlash()}/refresh",
                         "${authBasePath.ensureLeadingSlash()}/logout"
                     ).permitAll()
+                    .requestMatchers("${rolesBasePath.ensureLeadingSlash()}/**").permitAll()
                     .requestMatchers("/api/v1/unsecure/**").permitAll()
                     .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**", "/webjars/**").permitAll()
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()


### PR DESCRIPTION
## Summary
- allow unauthenticated calls to the roles API by permitting the roles base path in the security filter chain

## Testing
- ./gradlew test *(fails: missing Java toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_690a62895658832ebd47ee3f136179e3